### PR TITLE
added position sticky to dropdown content

### DIFF
--- a/css/primetest.css
+++ b/css/primetest.css
@@ -176,6 +176,7 @@ body {
 /* Show the dropdown menu on hover */
 .dropdown:hover .dropdown-content {
   display: block;
+  position:sticky;
 }
 
 


### PR DESCRIPTION
adding position:sticky on line 179 makes the dropdown menu stick to the top nav bar, also when the user scrolls down. The issue this creates is that it overrides the overflow:hidden element of the topnav bar, thus showing the background-color:black over the whole width of the nav.

in response to issue #13 